### PR TITLE
Added loop to extract multiple Host aliases.

### DIFF
--- a/zsh-ssh.zsh
+++ b/zsh-ssh.zsh
@@ -75,23 +75,28 @@ _ssh-host-list() {
         key = tmp[1]
         value = tmp[2]
 
-        if (key == "Host") { alias = value }
+        if (key == "Host") { aliases = value }
         if (key == "Hostname") { host_name = value }
         if (key == "#_Desc") { desc = value }
       }
 
-      if (!host_name && alias ) {
-        host_name = alias
-      }
+	  split(aliases, alias_list, " ")
+	  for( i in  alias_list)	{
+		  alias = alias_list[i]
 
-      if (desc) {
-        desc_formated = sprintf("[\033[00;34m%s\033[0m]", desc)
-      }
+		  if (!host_name && alias ) {
+			  host_name = alias
+		  }
 
-      if ((host_name && host_name != "*") || (alias && alias != "*")) {
-        host = sprintf("%s|->|%s|%s\n", alias, host_name, desc_formated)
-        host_list = host_list host
-      }
+		  if (desc) {
+			  desc_formated = sprintf("[\033[00;34m%s\033[0m]", desc)
+		  }
+
+		  if ((host_name && host_name != "*") || (alias && alias != "*")) {
+			  host = sprintf("%s|->|%s|%s\n", alias, host_name, desc_formated)
+			  host_list = host_list host
+		  }
+	  }
     }
     END {
       print host_list


### PR DESCRIPTION
ssh_config allows the following statements:

```
Host alias1 anotheralias
    #Config for all aliases
```

Changes to `zsh-ssh.zsh` add each listed alias to the returned list of ssh hosts when tab completing ssh.