### PR TITLE
Fix: Add better separator for hosts to avoid host skipping.

### DIFF
--- a/zsh-ssh.zsh
+++ b/zsh-ssh.zsh
@@ -44,6 +44,7 @@ _ssh_host_list() {
 
   ssh_config=$(_parse_config_file $SSH_CONFIG_FILE)
   ssh_config=$(echo $ssh_config | command grep -v -E "^\s*#[^_]")
+  ssh_config=$(echo $ssh_config | command sed "s/^[ \t]*host /@@host /gi")
 
   host_list=$(echo $ssh_config | command awk '
     function join(array, start, end, sep, result, i) {
@@ -81,7 +82,7 @@ _ssh_host_list() {
     BEGIN {
       IGNORECASE = 1
       FS="\n"
-      RS=""
+      RS="@@"
 
       host_list = ""
     }


### PR DESCRIPTION
I found that this was skipping some hosts configurations that I had (i have ~300 hosts) .
By making record separator more specific I got it working in a more reliable way.
Separating records by `@@` before each host declaration seems to work nicely and it AFAIK shouldn't collide with any other configuration thing easily. For modifiying the ssh_configuration i used sed with regex `s/[ \t]*host`, which should make the addition safely and in at least realitvely compatible way for different sed implementations.