### PR TITLE
Fix: Detect and use fzf-tab-complete when available

### DIFF
--- a/zsh-ssh.zsh
+++ b/zsh-ssh.zsh
@@ -257,10 +257,16 @@ fzf_complete_ssh() {
   binding=$(bindkey '^I')
   [[ $binding =~ 'undefined-key' ]] || fzf_ssh_default_completion=$binding[(s: :w)2]
   unset binding
+  
+  # Check if fzf-tab is loaded and use it as fallback if available
+  if (( $+functions[fzf-tab-complete] )); then
+    fzf_ssh_default_completion="fzf-tab-complete"
+  fi
 }
 
 
+zle -N fzf-ssh-complete fzf_complete_ssh
 zle -N fzf_complete_ssh
-bindkey '^I' fzf_complete_ssh
+bindkey '^I' fzf-ssh-complete
 
 # vim: set ft=zsh sw=2 ts=2 et


### PR DESCRIPTION
## Summary
- Fixed integration issue with fzf-tab plugin where wrong fallback widget was captured
- Added detection for fzf-tab-complete function to use it as fallback when available
- Renamed widget to fzf-ssh-complete for consistency

## Problem
The plugin was capturing the Tab key binding at plugin load time, before fzf-tab was fully initialized. This caused it to save `expand-or-complete` as the fallback instead of `fzf-tab-complete`, breaking tab completion for non-SSH commands.

## Solution
Added a check after capturing the initial binding to detect if fzf-tab-complete function is available and use it as the fallback. This ensures proper integration with fzf-tab while maintaining backward compatibility.

## Test plan
- [x] Test with fzf-tab loaded before zsh-ssh
- [x] Test tab completion for SSH commands
- [x] Test tab completion for non-SSH commands
- [x] Verify fzf-tab works correctly for regular completions

🤖 Generated with [Claude Code](https://claude.ai/code)